### PR TITLE
Actions: Run only on PR event or `main` push

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,7 +2,10 @@ name: Build and test
 on: [ pull_request, push ]
 jobs:
   JVM-Run-Gradle-Check:
+    name: Build and test
     runs-on: ubuntu-latest
+    # Run if github push is main branch or pull request
+    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +23,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-
-      - name: Check
-        run: ./gradlew check
+          arguments: check --continue
+          cache-read-only: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
This avoids building twice for each commit in a PR.

<img width="840" alt="image" src="https://github.com/Faire/faire-detekt-rules/assets/302365/52d43fa5-0060-4969-a09e-f45f7448507e">
