### PR TITLE
Create new rule: NoFunctionReferenceToJavaClass

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="1.9.23" />
   </component>
 </project>

--- a/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
+++ b/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
@@ -12,6 +12,7 @@ import com.faire.detekt.rules.DoNotUseSingleOnFilter
 import com.faire.detekt.rules.DoNotUseSizePropertyInAssert
 import com.faire.detekt.rules.GetOrDefaultShouldBeReplacedWithGetOrElse
 import com.faire.detekt.rules.NoExtensionFunctionOnNullableReceiver
+import com.faire.detekt.rules.NoFunctionReferenceToJavaClass
 import com.faire.detekt.rules.NoNonPrivateGlobalVariables
 import com.faire.detekt.rules.NoNullableLambdaWithDefaultNull
 import com.faire.detekt.rules.NoPairWithAmbiguousTypes
@@ -45,6 +46,7 @@ internal class FaireRulesProvider : RuleSetProvider {
       DoNotUseSizePropertyInAssert(config),
       GetOrDefaultShouldBeReplacedWithGetOrElse(config),
       NoExtensionFunctionOnNullableReceiver(config),
+      NoFunctionReferenceToJavaClass(config),
       NoNonPrivateGlobalVariables(config),
       NoNullableLambdaWithDefaultNull(config),
       NoPairWithAmbiguousTypes(config),

--- a/src/main/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClass.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClass.kt
@@ -1,6 +1,12 @@
 package com.faire.detekt.rules
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 
 /**

--- a/src/main/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClass.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClass.kt
@@ -1,0 +1,45 @@
+package com.faire.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+
+/**
+ * No use of `::javaClass`; use `.javaClass` instead.
+ *
+ * `Foo::bar` gives you a reference to function/property `bar` on class `Foo`:
+ * https://kotlinlang.org/docs/reflection.html#function-references
+ * [javaClass] is an extension function on [Any]:
+ * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/java-class.html
+ *
+ * 99% of the time, you want to get the JVM class of some class/object instead of the callable reference to this
+ * extension function. This bug can hide deep if you then proceed to call any method on [Class]: e.g.
+ * ```
+ * println(Foo::javaClass.simpleName) // gives you "javaClass"
+ * println(Foo.javaClass.simpleName)  // gives you "Foo"
+ * ```
+ */
+internal class NoFunctionReferenceToJavaClass(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.CodeSmell,
+        description = RULE_DESCRIPTION,
+        debt = Debt.FIVE_MINS,
+    )
+
+    override fun visitCallableReferenceExpression(expression: KtCallableReferenceExpression) {
+        super.visitCallableReferenceExpression(expression)
+        if (expression.callableReference.getReferencedName() == "javaClass") {
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(expression),
+                    message = RULE_DESCRIPTION,
+                ),
+            )
+        }
+    }
+
+    companion object {
+        const val RULE_DESCRIPTION = "Do not call ::javaClass; did you mean .javaClass?"
+    }
+}

--- a/src/test/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClassTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/NoFunctionReferenceToJavaClassTest.kt
@@ -1,0 +1,34 @@
+package com.faire.detekt.rules
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class NoFunctionReferenceToJavaClassTest {
+  private val rule: NoFunctionReferenceToJavaClass = NoFunctionReferenceToJavaClass()
+
+  @Test
+  fun `should report double-colon javaClass`() {
+    val findings = rule.lint(
+        """
+        class Foo
+        val buggy = Foo::javaClass.name
+        """.trimIndent(),
+    )
+
+    assertThat(findings).hasSize(1)
+    assertThat(findings.first().issue.id).isEqualTo("NoFunctionReferenceToJavaClass")
+  }
+
+  @Test
+  fun `should not report dot javaClass`() {
+      val findings = rule.lint(
+          """
+          class Foo
+          val correct = Foo.javaClass.name
+          """.trimIndent(),
+      )
+
+    assertThat(findings).isEmpty()
+  }
+}


### PR DESCRIPTION
Drive-by: check in some auto generated changes in `.idea` (probably due to a newer version of IntelliJ)