### PR TITLE
Bump project gradle version to 0.2.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ kotlin.code.style=official
 
 GROUP=com.faire
 POM_ARTIFACT_ID=faire-detekt-rules
-VERSION_NAME=0.2.3
+VERSION_NAME=0.2.4


### PR DESCRIPTION
Following these steps from @Adriel-M to get my rule available in the backend repo - https://github.com/Faire/faire-detekt-rules/pull/37

To do a release you must:
* [This PR] bump version here (after your change gets merged in): https://github.com/Faire/faire-detekt-rules/blob/main/gradle.properties
* Run this workflow https://github.com/Faire/faire-detekt-rules/actions/workflows/release.yml (at this point, this is going to publish to maven central :nodders: )
* (optional but you should) git tag that commit to the same version in 1
* create a release here: https://github.com/Faire/faire-detekt-rules/releases
* If you want to test out the rule on backend before actually creating a release, I did create this write up in our other repo: https://github.com/Faire/sqldelight-cockroachdb-dialect?tab=readme-ov-file#using-a-snapshot-release