### PR TITLE
Add NoDuplicateKeysInMapOf rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ FaireRuleSet:
     active: true
   GetOrDefaultShouldBeReplacedWithGetOrElse:
     active: true
+  NoDuplicateKeysInMapOf:
+    active: true
   NoExtensionFunctionOnNullableReceiver:
     active: true
   NoNonPrivateGlobalVariables:

--- a/detekt.yaml
+++ b/detekt.yaml
@@ -117,6 +117,8 @@ FaireRuleSet:
     active: true
   GetOrDefaultShouldBeReplacedWithGetOrElse:
     active: true
+  NoDuplicateKeysInMapOf:
+    active: true
   NoExtensionFunctionOnNullableReceiver:
     active: true
   NoNonPrivateGlobalVariables:

--- a/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
+++ b/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
@@ -12,6 +12,7 @@ import com.faire.detekt.rules.DoNotUsePropertyAccessInAssert
 import com.faire.detekt.rules.DoNotUseSingleOnFilter
 import com.faire.detekt.rules.DoNotUseSizePropertyInAssert
 import com.faire.detekt.rules.GetOrDefaultShouldBeReplacedWithGetOrElse
+import com.faire.detekt.rules.NoDuplicateKeysInMapOf
 import com.faire.detekt.rules.NoExtensionFunctionOnNullableReceiver
 import com.faire.detekt.rules.NoFunctionReferenceToJavaClass
 import com.faire.detekt.rules.NoNonPrivateGlobalVariables
@@ -47,6 +48,7 @@ internal class FaireRulesProvider : RuleSetProvider {
       DoNotUseSingleOnFilter(config),
       DoNotUseSizePropertyInAssert(config),
       GetOrDefaultShouldBeReplacedWithGetOrElse(config),
+      NoDuplicateKeysInMapOf(config),
       NoExtensionFunctionOnNullableReceiver(config),
       NoFunctionReferenceToJavaClass(config),
       NoNonPrivateGlobalVariables(config),

--- a/src/main/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOf.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOf.kt
@@ -69,6 +69,9 @@ internal class NoDuplicateKeysInMapOf(config: Config = Config.empty) : Rule(conf
     // Handle key value pairs
     if (argumentExpression is KtBinaryExpression) {
       val leftExpression = argumentExpression.left
+      if (argumentExpression.operationReference.text != "to") {
+        return null
+      }
       return extractKeyFromExpression(leftExpression)
     }
 

--- a/src/main/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOf.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOf.kt
@@ -1,0 +1,87 @@
+package com.faire.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+/**
+ * This rule checks for duplicate keys in mapOf and mutableMapOf calls.
+ *
+ * ```
+ * // Good
+ * val map = mapOf(
+ *     "key1" to "value1",
+ *     "key2" to "value2",
+ * )
+ *
+ * // Bad
+ * val map = mapOf(
+ *     "key1" to "value1",
+ *     "key1" to "value2",
+ * )
+ * ```
+ */
+internal class NoDuplicateKeysInMapOf(config: Config = Config.empty) : Rule(config) {
+  override val issue: Issue = Issue(
+    id = javaClass.simpleName,
+    severity = Severity.Warning,
+    description = "NoDuplicateKeysInMapOf",
+    debt = Debt.FIVE_MINS,
+  )
+
+  override fun visitCallExpression(expression: KtCallExpression) {
+    super.visitCallExpression(expression)
+
+    val text = expression.calleeExpression?.text
+    if (text == "mapOf" || text == "mutableMapOf") {
+      val arguments = expression.valueArguments
+      val keys = mutableSetOf<String>()
+
+      for (argument in arguments) {
+        val key = extractKey(argument)
+        if (key != null) {
+          if (!keys.add(key)) {
+            report(
+              CodeSmell(
+                issue,
+                Entity.from(argument),
+                message = "The key $key is duplicated in the map.",
+              ),
+            )
+          }
+        }
+      }
+    }
+  }
+
+  private fun extractKey(argument: KtValueArgument): String? {
+    val argumentExpression = argument.getArgumentExpression() ?: return null
+
+    // Handle key value pairs
+    if (argumentExpression is KtBinaryExpression) {
+      val leftExpression = argumentExpression.left
+      return extractKeyFromExpression(leftExpression)
+    }
+
+    // Handle other expressions directly
+    return extractKeyFromExpression(argumentExpression)
+  }
+
+  private fun extractKeyFromExpression(expression: KtExpression?): String? {
+    // Skip function calls as they could generate unique values (e.g. random id generator)
+    return if (expression == null || expression is KtCallExpression || expression is KtDotQualifiedExpression) {
+      null
+    } else {
+      expression.text
+    }
+  }
+}

--- a/src/test/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOfTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOfTest.kt
@@ -99,4 +99,22 @@ internal class NoDuplicateKeysInMapOfTest {
     val findings = rule.lint(ktFile)
     assertThat(findings).isEmpty()
   }
+
+  @Test
+  fun `should not report for constant, variable, and function with same name`() {
+    val ktFile = compileContentForTest(
+      """
+          val key1 = "key1"
+          fun getKey() = "key1"
+          val map = mapOf(
+              "key1" to "value3",
+              key1 to "value2",
+              key1() to "value1",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings).isEmpty()
+  }
 }

--- a/src/test/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOfTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/NoDuplicateKeysInMapOfTest.kt
@@ -1,0 +1,102 @@
+package com.faire.detekt.rules
+
+import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class NoDuplicateKeysInMapOfTest {
+  private lateinit var rule: NoDuplicateKeysInMapOf
+
+  @BeforeEach
+  fun setup() {
+    rule = NoDuplicateKeysInMapOf()
+  }
+
+  @Test
+  fun `should not report when map has no duplicate keys`() {
+    val ktFile = compileContentForTest(
+      """
+          val map = mapOf(
+              "key1" to "value1",
+              "key2" to "value2",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings).isEmpty()
+  }
+
+  @Test
+  fun `should report when map has duplicate keys`() {
+    val ktFile = compileContentForTest(
+      """
+          val map = mapOf(
+              "key1" to "value1",
+              "key1" to "value2",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings)
+      .singleElement()
+      .extracting { it.message }
+      .isEqualTo("The key \"key1\" is duplicated in the map.")
+  }
+
+  @Test
+  fun `should report for mutable map with duplicate keys`() {
+    val ktFile = compileContentForTest(
+      """
+          val map = mutableMapOf(
+              "key1" to "value1",
+              "key1" to "value2",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings)
+      .singleElement()
+      .extracting { it.message }
+      .isEqualTo("The key \"key1\" is duplicated in the map.")
+  }
+
+  @Test
+  fun `should report for duplicate keys when key is a variable`() {
+    val ktFile = compileContentForTest(
+      """
+          fun key1 = "key1"
+          val map = mapOf(
+              key1 to "value1",
+              key1 to "value2",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings)
+      .singleElement()
+      .extracting { it.message }
+      .isEqualTo("The key key1 is duplicated in the map.")
+  }
+
+  @Test
+  fun `should not report for duplicate keys when key is a function call`() {
+    val ktFile = compileContentForTest(
+      """
+          fun getKey() = "key1"
+          val map = mapOf(
+              getKey() to "value1",
+              getKey() to "value2",
+          )
+        """.trimIndent(),
+    )
+
+    val findings = rule.lint(ktFile)
+    assertThat(findings).isEmpty()
+  }
+}


### PR DESCRIPTION
Adding a new detekt rule to detect duplicate keys in `mapOf` and `mutableMapOf` calls.

It skips keys created by function calls as they could generate unique values (e.g. random id generator).

Moving rule over as per [comment](https://github.com/Faire/backend/pull/148652#discussion_r1635055525)