### PR TITLE
Rule: Require more than one statement per `with` block

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,13 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="RIGHT_MARGIN" value="150" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/src/main/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActions.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActions.kt
@@ -1,0 +1,61 @@
+package com.faire.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+/**
+ * In a with() block there must be multiple statements acting on the receiver.
+ *
+ * Good example:
+ *
+ * ```
+ * fun `test usage`() {
+ *    with(subject.action()) {
+ *      assertThat(property).isEqualTo(true)
+ *      assertThat(otherProperty).isEqualTo(false)
+ *    }
+ * ```
+ *
+ * Bad example:
+ *
+ * ```
+ * fun `test usage`() {
+ *    with(subject.action()) {
+ *      assertThat(property).isEqualTo(true)
+ *    }
+ * ```
+ */
+internal class WithReceiverShouldHaveMultipleActions(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Style,
+        description = "With block receiver should have multiple actions",
+        debt = Debt.FIVE_MINS,
+    )
+
+    override fun visitBlockExpression(expression: KtBlockExpression) {
+        super.visitBlockExpression(expression)
+        val parentWithStatement = expression.getParentOfType<KtCallExpression>(true) ?: return
+        if (!parentWithStatement.isWithExpr()) return
+
+        if (expression.countChildren(null) <= 1) {
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(parentWithStatement),
+                    message = issue.description,
+                )
+            )
+        }
+    }
+}
+
+private fun KtCallExpression.isWithExpr(): Boolean = calleeExpression?.textMatches("with") == true

--- a/src/main/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActions.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActions.kt
@@ -52,7 +52,7 @@ internal class WithReceiverShouldHaveMultipleActions(config: Config = Config.emp
                     issue = issue,
                     entity = Entity.from(parentWithStatement),
                     message = issue.description,
-                )
+                ),
             )
         }
     }

--- a/src/test/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActionsTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActionsTest.kt
@@ -1,0 +1,66 @@
+package com.faire.detekt.rules
+
+import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
+import io.github.detekt.test.utils.createEnvironment
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val ISSUE_DESCRIPTION = "With block receiver should have multiple actions"
+
+internal class WithReceiverShouldHaveMultipleActionsTest {
+    private lateinit var rule: WithReceiverShouldHaveMultipleActions
+    private lateinit var envWrapper: KotlinCoreEnvironmentWrapper
+
+    @BeforeEach
+    fun setUp() {
+        rule = WithReceiverShouldHaveMultipleActions()
+        envWrapper = createEnvironment(listOf())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        envWrapper.dispose()
+    }
+
+    @Test
+    fun `with() having a single call to receiver is flagged`() {
+        val findings = rule.compileAndLintWithContext(
+            envWrapper.env,
+            """
+            fun foo() {
+                val receiver = "foobar"
+                with(receiver) {
+                    assertThat(length).isEqualTo(10)
+                }
+            }
+        """.trimIndent()
+        )
+        assertThat(findings).hasSize(1)
+        with(findings.first().issue) {
+            assertThat(id).isEqualTo("WithReceiverShouldHaveMultipleActions")
+            assertThat(description).isEqualTo(ISSUE_DESCRIPTION)
+            assertThat(severity).isEqualTo(Severity.Style)
+        }
+    }
+
+    @Test
+    fun `with() having a multiple calls to receiver is not flagged`() {
+        val findings = rule.compileAndLintWithContext(
+            envWrapper.env,
+            """
+            fun foo() {
+                val receiver = "foobar"
+                with(receiver) {
+                    assertThat(length).isEqualTo(10)
+                    assertThat(length).isNotEqualTo(8)
+                }
+            }
+        """.trimIndent()
+        )
+        assertThat(findings).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActionsTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/WithReceiverShouldHaveMultipleActionsTest.kt
@@ -37,7 +37,7 @@ internal class WithReceiverShouldHaveMultipleActionsTest {
                     assertThat(length).isEqualTo(10)
                 }
             }
-        """.trimIndent()
+        """.trimIndent(),
         )
         assertThat(findings).hasSize(1)
         with(findings.first().issue) {
@@ -59,7 +59,7 @@ internal class WithReceiverShouldHaveMultipleActionsTest {
                     assertThat(length).isNotEqualTo(8)
                 }
             }
-        """.trimIndent()
+        """.trimIndent(),
         )
         assertThat(findings).isEmpty()
     }


### PR DESCRIPTION
[FD-43685](https://fairewholesale.atlassian.net/browse/FD-43685)

Create a detektor validator for our styleguide rule for with blocks:
```
// Good
with(brandOrder.incomingPayment) {
  assertThat(state).isEqualTo(State.COMPLETE)
  assertThat(amountCents).isEqualTo(4_42L)
}

// Bad (only 1 action on the receiver)
with(brandOrder.incomingPayment) {
  assertThat(state).isEqualTo(State.COMPLETE)
}
```

[FD-43685]: https://fairewholesale.atlassian.net/browse/FD-43685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ