### PR TITLE
release: Fix release scripts to pass `--no-configuration-cache`

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -36,4 +36,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-parallel
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-parallel --no-configuration-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-parallel
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-parallel --no-configuration-cache


### PR DESCRIPTION
`--no-configuration-cache` is required as publication is not configuration cache compliant.