### PR TITLE
Add DoNotAssertIsEqualOnTheResultOfSingle rule

### DIFF
--- a/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
+++ b/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
@@ -2,6 +2,7 @@ package com.faire.detekt
 
 import com.faire.detekt.rules.AlwaysUseIsTrueOrIsFalse
 import com.faire.detekt.rules.DoNotAccessVisibleForTesting
+import com.faire.detekt.rules.DoNotAssertIsEqualOnTheResultOfSingle
 import com.faire.detekt.rules.DoNotSplitByRegex
 import com.faire.detekt.rules.DoNotUseDirectReceiverReferenceInsideWith
 import com.faire.detekt.rules.DoNotUseHasSizeForEmptyListInAssert
@@ -38,6 +39,7 @@ internal class FaireRulesProvider : RuleSetProvider {
     listOf(
       AlwaysUseIsTrueOrIsFalse(config),
       DoNotAccessVisibleForTesting(config),
+      DoNotAssertIsEqualOnTheResultOfSingle(config),
       DoNotSplitByRegex(config),
       DoNotUseDirectReceiverReferenceInsideWith(config),
       DoNotUsePropertyAccessInAssert(config),

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -62,7 +62,7 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
 
             val argumentsForIsEqualExpression = (isEqualExpression as? KtCallExpression)?.valueArgumentList?.text
             isEqualExpression.astReplace(
-                KtPsiFactory(isEqualExpression).createExpression("containsOnly$argumentsForIsEqualExpression")
+                KtPsiFactory(isEqualExpression).createExpression("containsOnly$argumentsForIsEqualExpression"),
             )
         }
     }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -41,7 +41,7 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
         if (selectorExpression.referenceExpression()?.text != "isEqualTo") return
 
         val assertThatExpression = receiverExpression as? KtCallExpression ?: return
-        if(!assertThatExpression.isAssertingOnResultOfSingle()) return
+        if (!assertThatExpression.isAssertingOnResultOfSingle()) return
 
         report(
             CodeSmell(
@@ -53,7 +53,7 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
     }
 
     private fun KtCallExpression.isAssertingOnResultOfSingle(): Boolean {
-        val argument = valueArguments.singleOrNull()?: return false
+        val argument = valueArguments.singleOrNull() ?: return false
 
         return argument.text.endsWith(".single()")
     }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -1,0 +1,60 @@
+package com.faire.detekt.rules
+
+import com.faire.detekt.utils.isAssertThat
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
+
+/**
+ * Do not assert isEqual on the result of single(). Instead, use containsOnly.
+ *
+ * ```
+ * // Good
+ * assertThat(listof("a")).containsOnly("a")
+ *
+ * // Bad
+ * assertThat(listof("a").single()).isEqualTo("a")
+ * ```
+ */
+internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Warning,
+        description = "use containsOnly() instead of asserting isEqual() on the result of single()",
+        debt = Debt.FIVE_MINS,
+    )
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        super.visitDotQualifiedExpression(expression)
+
+        val selectorExpression = expression.selectorExpression ?: return
+        val receiverExpression = expression.receiverExpression
+
+        if (!receiverExpression.isAssertThat()) return
+        if (selectorExpression.referenceExpression()?.text != "isEqualTo") return
+
+        val assertThatExpression = receiverExpression as? KtCallExpression ?: return
+        if(!assertThatExpression.isAssertingOnResultOfSingle()) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(expression),
+                message = "containsOnly should be used instead of asserting isEqual on the result of single()",
+            ),
+        )
+    }
+
+    private fun KtCallExpression.isAssertingOnResultOfSingle(): Boolean {
+        val argument = valueArguments.singleOrNull()?: return false
+
+        return argument.text.endsWith(".single()")
+    }
+}

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -44,7 +44,8 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
         if (isEqualExpression.referenceExpression()?.text != "isEqualTo") return
 
         val assertThatExpression = receiverExpression as? KtCallExpression ?: return
-        val argumentForAssertThatExpression = assertThatExpression.valueArguments.singleOrNull()?.getArgumentExpression() ?: return
+        val argumentForAssertThatExpression =
+            assertThatExpression.valueArguments.singleOrNull()?.getArgumentExpression() ?: return
         if (!argumentForAssertThatExpression.callsSingleWithNoArgumentAtTheEnd()) return
 
         report(
@@ -60,12 +61,15 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
             argumentForAssertThatExpression.lastChild.delete() // Delete "."
 
             val argumentsForIsEqualExpression = (isEqualExpression as? KtCallExpression)?.valueArgumentList?.text
-            isEqualExpression.astReplace(KtPsiFactory(isEqualExpression).createExpression("containsOnly$argumentsForIsEqualExpression"))
+            isEqualExpression.astReplace(
+                KtPsiFactory(isEqualExpression).createExpression("containsOnly$argumentsForIsEqualExpression")
+            )
         }
     }
 
     private fun KtExpression.callsSingleWithNoArgumentAtTheEnd(): Boolean {
-        // If argument expression ends with single(), then the whole expression is a dot qualified expression with single as its selector expression
+        // If argument expression does actually end with single(), then this would mean that the whole expression is
+        // a dot qualified expression with single as its selector expression
         val selectorExpression = (this as? KtDotQualifiedExpression)?.selectorExpression ?: return false
 
         // Check if the callee is single() with no arguments e.g. single { it > 0 }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -18,6 +18,9 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 /**
  * Do not assert isEqual on the result of single(). Instead, use containsOnly.
  *
+ * Using .single() will throw an exception if the collection does not contain exactly one element.
+ * The exception results in the assertion failure message being hidden, which makes debugging more difficult.
+ *
  * ```
  * // Good
  * assertThat(listof("a")).containsOnly("a")

--- a/src/test/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingleTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingleTest.kt
@@ -1,0 +1,45 @@
+package com.faire.detekt.rules
+
+import com.faire.detekt.utils.AutoCorrectRuleTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class DoNotAssertIsEqualOnTheResultOfSingleTest : AutoCorrectRuleTest<DoNotAssertIsEqualOnTheResultOfSingle> (
+    { DoNotAssertIsEqualOnTheResultOfSingle(it) },
+) {
+    @Test
+    fun `asserting isEqualTo does not produce an error if there's no call to single()`() {
+        assertNoViolations(
+            """
+          fun foo() {
+            assertThat(someValue).isEqualTo(someValue)
+          }
+        """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `asserting isEqualTo does not produce an error if it's not called directly on the result of single()`() {
+        assertNoViolations(
+            """
+          fun foo() {
+            assertThat(someList.single().someMethod()).isEqualTo(someValue)
+            assertThat(someList.single().somePeroperty).isEqualTo(someValue)
+          }
+        """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `asserting isEqualTo on the result of single() would produce an error`() {
+        val findings = rule.lint(
+            """
+          fun foo() {
+            assertThat(bar.baz.qux.single()).isEqualTo(someValue)
+          }
+        """.trimIndent(),
+        )
+        assertThat(findings.single().id).isEqualTo("DoNotAssertIsEqualOnTheResultOfSingle")
+    }
+}

--- a/src/test/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingleTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingleTest.kt
@@ -3,7 +3,8 @@ package com.faire.detekt.rules
 import com.faire.detekt.utils.AutoCorrectRuleTest
 import org.junit.jupiter.api.Test
 
-private const val RULE_DESCRIPTION = "containsOnly should be used instead of asserting isEqual on the result of single()"
+private const val RULE_DESCRIPTION =
+    "containsOnly should be used instead of asserting isEqual on the result of single()"
 
 internal class DoNotAssertIsEqualOnTheResultOfSingleTest : AutoCorrectRuleTest<DoNotAssertIsEqualOnTheResultOfSingle>(
     { DoNotAssertIsEqualOnTheResultOfSingle(it) },


### PR DESCRIPTION
Adding a new detekt rule to prevent asserting `isEqual` on `.single()`

```
// Good
assertThat(listof("a")).containsOnly("a")

// Bad
 assertThat(listof("a").single()).isEqualTo("a")
```

JIRA: https://fairewholesale.atlassian.net/browse/FD-193306