### PR TITLE
chore: Setup release v0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.2.5"
+version = "0.3.0"
 
 if (!providers.environmentVariable("RELEASE").isPresent) {
   val gitSha = providers.environmentVariable("GITHUB_SHA")


### PR DESCRIPTION
Setup for `0.3.0` release. 

Chose to do a minor release as the version of detekt was bumped.