### PR TITLE
release: Set version to 0.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.3.0"
+version = "0.4.0"
 
 if (!providers.environmentVariable("RELEASE").isPresent) {
   val gitSha = providers.environmentVariable("GITHUB_SHA")


### PR DESCRIPTION
Creating a 0.4.0 release to include Kotlin 2 artifact. As far as we know, K2 is backwards compatible so a minor release seems reasonable. 