### PR TITLE
fix: Do not consider parameter default values as unused let return values

### DIFF
--- a/src/main/kotlin/com/faire/detekt/rules/ReturnValueOfLetMustBeUsed.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/ReturnValueOfLetMustBeUsed.kt
@@ -14,10 +14,12 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 /**
  * This rule checks that the return value of a let is used - assigned, returned or captured in a collection.
@@ -59,6 +61,7 @@ internal class ReturnValueOfLetMustBeUsed(config: Config = Config.empty) : Rule(
         currentParent is KtValueArgument -> return
         currentParent is KtNamedFunction && isSingleLineFunction(currentParent) -> return
         currentParent is KtDestructuringDeclaration -> return
+        currentParent is KtParameter && currentParent.elementType == KtStubElementTypes.VALUE_PARAMETER -> return
 
         else -> {
           currentChild = currentChild.parent

--- a/src/test/kotlin/com/faire/detekt/rules/ReturnValueOfLetMustBeUsedTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/ReturnValueOfLetMustBeUsedTest.kt
@@ -184,6 +184,22 @@ internal class ReturnValueOfLetMustBeUsedTest {
   }
 
   @Test
+  fun `let expression can be used in parameter default values`() {
+    val findings = rule.lint(
+        """
+        fun testFunc(
+            foo: Int?,
+            bar: Int? = foo?.let { it + 2 },
+        ): Int {
+            return (foo ?: 0) + (bar ?: 0)
+        }
+      """.trimIndent(),
+    )
+
+    assertThat(findings).isEmpty()
+  }
+
+  @Test
   fun `let expression can be used in anonymous interface implementations`() {
     val findings = rule.lint(
         """


### PR DESCRIPTION
Currently, if `let` is used to compute the default value of a function parameter, the `ReturnValueOfLetMustBeUsed` rule will falsely flag that as a violation. In reality, it is a perfectly legitimate case.