### PR TITLE
fix: Upgrade DoNotUseSizePropertyInAssert to avoid false positives

### DIFF
--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseSizePropertyInAssert.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseSizePropertyInAssert.kt
@@ -1,6 +1,7 @@
 package com.faire.detekt.rules
 
 import com.faire.detekt.utils.isAssertThat
+import com.faire.detekt.utils.isTypeResolutionAvailable
 import com.faire.detekt.utils.usesSizeProperty
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
@@ -9,12 +10,20 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns.isCollectionOrNullableCollection
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns.isMapOrNullableMap
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.util.getType
+import org.jetbrains.kotlin.types.KotlinType
 
 /**
- * In a test, we should always use the hasSize() assertion method instead of  comparing the size property to some value.
+ * In a test, we should always use the hasSize() assertion method instead of comparing the size property to some value.
  *
  * One exception to using hasSize() is that it should not be used with an argument of zero. Use isEmpty() instead.
  * See [DoNotUseHasSizeForEmptyListInAssert].
@@ -47,6 +56,9 @@ internal class DoNotUseSizePropertyInAssert(config: Config = Config.empty) : Rul
 
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
+    if (!isTypeResolutionAvailable()) {
+      return
+    }
 
     val selectorExpression = expression.selectorExpression ?: return
     val receiverExpression = expression.receiverExpression
@@ -59,16 +71,51 @@ internal class DoNotUseSizePropertyInAssert(config: Config = Config.empty) : Rul
     val assertExpression = receiverExpression as? KtCallExpression ?: return
     val isEqualToOrIsZeroExpression = selectorExpression as? KtCallExpression ?: return
 
-    if (assertExpression.usesSizeProperty() && isEqualToOrIsZeroExpression.numericComparison()) {
-      report(
-          CodeSmell(
-              issue = issue,
-              entity = Entity.from(expression),
-              message = issue.description,
-          ),
-      )
+    if (!assertExpression.usesSizeProperty() || !isEqualToOrIsZeroExpression.numericComparison()) {
+      return
     }
+
+    val assertArgument = assertExpression.valueArguments.singleOrNull()?.getArgumentExpression() ?: return
+    val mapType = when (assertArgument) {
+      // assertThat(size)
+      is KtNameReferenceExpression -> getImplicitThisType(assertArgument)
+      // assertThat(something.something.size)
+      is KtDotQualifiedExpression -> assertArgument.receiverExpression.getType(bindingContext)
+      else -> null
+    } ?: return
+    if (!mapType.isCollectionOrMap()) {
+      return
+    }
+
+    report(
+        CodeSmell(
+            issue = issue,
+            entity = Entity.from(expression),
+            message = issue.description,
+        ),
+    )
   }
+
+  private fun getImplicitThisType(expression: KtNameReferenceExpression): KotlinType? {
+    val descriptor = bindingContext[BindingContext.REFERENCE_TARGET, expression] ?: return null
+
+    // For a member property or function, find its dispatch receiver (implicit "this")
+    val containingClassType = when (descriptor) {
+      is PropertyDescriptor -> descriptor.dispatchReceiverParameter?.type
+      is FunctionDescriptor -> descriptor.dispatchReceiverParameter?.type
+      else -> null
+    }
+
+    return containingClassType
+  }
+}
+
+private fun KotlinType.isCollectionOrMap(): Boolean {
+  return isExactlyCollectionOrMap() || constructor.supertypes.any { it.isExactlyCollectionOrMap() }
+}
+
+private fun KotlinType.isExactlyCollectionOrMap(): Boolean {
+  return isCollectionOrNullableCollection(this) || isMapOrNullableMap(this)
 }
 
 private fun KtCallExpression.numericComparison(): Boolean {


### PR DESCRIPTION
Currently, the "do not use .size on asserts" has several flaws and false positives. A simple example is if `size` is called on something that is not a map/collection, for which we have some suppressions on our main codebase already.
This makes the rule much smarter, and also support new use cases, such as within a `with` or other implicit `this` contexts.