### PR TITLE
chore: Bump version and release 0.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.4.1"
+version = "0.5.0"
 
 if (!providers.environmentVariable("RELEASE").isPresent) {
   val gitSha = providers.environmentVariable("GITHUB_SHA")


### PR DESCRIPTION
Note: I am doing a minor (=major for 0.x) due to my significant re-work of the `DoNotUseSizePropertyInAssert` rule which could cause potentially a large number of previously hidden issues to be flagged.