### PR TITLE
Remove unecessary dependency on detekt-formatting from build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
 
   implementation(libs.detekt.api)
 
-  runtimeOnly(libs.detekt.formatting)
-
   testImplementation(libs.assertj)
   testImplementation(libs.detekt.test)
   testImplementation(libs.guava)


### PR DESCRIPTION
As pointed out on https://github.com/Faire/faire-detekt-rules/issues/81, adding this dependency causes it to be included on projects that use the library, which brings in default configurations.

In fact we don't need it at all, because our plugin configuration already includes that.