### PR TITLE
chore: Bump version and release 0.5.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.5.0"
+version = "0.5.1"
 
 if (!providers.environmentVariable("RELEASE").isPresent) {
   val gitSha = providers.environmentVariable("GITHUB_SHA")


### PR DESCRIPTION
This should include the fix for https://github.com/Faire/faire-detekt-rules/issues/81