### PR TITLE
new rule - FilterNotNullOverMapNotNullForFiltering

### DIFF
--- a/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
+++ b/src/main/kotlin/com/faire/detekt/FaireRulesProvider.kt
@@ -13,6 +13,7 @@ import com.faire.detekt.rules.DoNotUseIsOneAssertions
 import com.faire.detekt.rules.DoNotUsePropertyAccessInAssert
 import com.faire.detekt.rules.DoNotUseSingleOnFilter
 import com.faire.detekt.rules.DoNotUseSizePropertyInAssert
+import com.faire.detekt.rules.FilterNotNullOverMapNotNullForFiltering
 import com.faire.detekt.rules.GetOrDefaultShouldBeReplacedWithGetOrElse
 import com.faire.detekt.rules.NoDuplicateKeysInMapOf
 import com.faire.detekt.rules.NoExtensionFunctionOnNullableReceiver
@@ -51,6 +52,7 @@ internal class FaireRulesProvider : RuleSetProvider {
           DoNotUseIsOneAssertions(config),
           DoNotUseSingleOnFilter(config),
           DoNotUseSizePropertyInAssert(config),
+          FilterNotNullOverMapNotNullForFiltering(config),
           GetOrDefaultShouldBeReplacedWithGetOrElse(config),
           NoDuplicateKeysInMapOf(config),
           NoExtensionFunctionOnNullableReceiver(config),

--- a/src/main/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFiltering.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFiltering.kt
@@ -1,0 +1,64 @@
+package com.faire.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
+
+/**
+ * Detects usage of `mapNotNull { it }` and suggests using `filterNotNull()` instead.
+ *
+ * Noncompliant code:
+ * ```kotlin
+ * listOf(1, null, 2).mapNotNull { it }
+ * ```
+ *
+ * Compliant code:
+ * ```kotlin
+ * listOf(1, null, 2).filterNotNull()
+ * ```
+ */
+internal class FilterNotNullOverMapNotNullForFiltering(config: Config = Config.empty) : Rule(config) {
+  override val issue = Issue(
+      id = javaClass.simpleName,
+      severity = Severity.Style,
+      description = "Use filterNotNull() instead of mapNotNull { it }",
+      debt = Debt.FIVE_MINS,
+  )
+
+  override fun visitCallExpression(expression: KtCallExpression) {
+    super.visitCallExpression(expression)
+
+    val callee = expression.getCalleeExpressionIfAny() ?: return
+    if (callee.text != "mapNotNull") return
+
+    val lambda = expression.lambdaArguments.firstOrNull()?.getLambdaExpression() ?: return
+    val lambdaBody = lambda.bodyExpression?.children?.firstOrNull() ?: return
+
+    if (lambdaBody is KtNameReferenceExpression && lambdaBody.getReferencedName() == "it") {
+      report(
+          CodeSmell(
+              issue = issue,
+              entity = Entity.from(expression),
+              message = "Replace mapNotNull { it } with filterNotNull()",
+          ),
+      )
+
+      withAutoCorrect {
+        val dotQualified = expression.parent as? KtDotQualifiedExpression ?: return@withAutoCorrect
+        val receiver = dotQualified.receiverExpression.text
+        val psiFactory = KtPsiFactory(expression)
+        val newExpression = psiFactory.createExpression("$receiver.filterNotNull()")
+        dotQualified.replace(newExpression)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFilteringTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFilteringTest.kt
@@ -1,6 +1,5 @@
 package com.faire.detekt.rules
 
-import com.faire.detekt.rules.FilterNotNullOverMapNotNullForFiltering
 import com.faire.detekt.utils.AutoCorrectRuleTest
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFilteringTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFilteringTest.kt
@@ -1,0 +1,95 @@
+package com.faire.detekt.rules
+
+import com.faire.detekt.rules.FilterNotNullOverMapNotNullForFiltering
+import com.faire.detekt.utils.AutoCorrectRuleTest
+import org.junit.jupiter.api.Test
+
+internal class FilterNotNullOverMapNotNullForFilteringTest :
+    AutoCorrectRuleTest<FilterNotNullOverMapNotNullForFiltering>(
+        { FilterNotNullOverMapNotNullForFiltering(it) },
+    ) {
+
+  @Test
+  fun `should detect and auto-correct mapNotNull { it } to filterNotNull()`() {
+    assertLintAndFormat(
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).mapNotNull { it }
+                }
+            """.trimIndent(),
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).filterNotNull()
+                }
+            """.trimIndent(),
+        issueDescription = "Replace mapNotNull { it } with filterNotNull()",
+    )
+  }
+
+  @Test
+  fun `should detect and auto-correct chained mapNotNull { it }`() {
+    assertLintAndFormat(
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).filter { it != 3 }.mapNotNull { it }.map { it * 2 }
+                }
+            """.trimIndent(),
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).filter { it != 3 }.filterNotNull().map { it * 2 }
+                }
+            """.trimIndent(),
+        issueDescription = "Replace mapNotNull { it } with filterNotNull()",
+    )
+  }
+
+  @Test
+  fun `should not detect mapNotNull with transformation`() {
+    assertNoViolations(
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).mapNotNull { it?.toString() }
+                }
+            """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `should not detect filterNotNull`() {
+    assertNoViolations(
+        """
+                fun test() {
+                    val result = listOf(1, null, 2).filterNotNull()
+                }
+            """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `should not detect regular map`() {
+    assertNoViolations(
+        """
+                fun test() {
+                    val result = listOf(1, 2, 3).map { it }
+                }
+            """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `should detect and auto-correct with complex receiver expression`() {
+    assertLintAndFormat(
+        """
+                fun test() {
+                    val result = getSomeList().filter { it.isValid() }.mapNotNull { it }
+                }
+            """.trimIndent(),
+        """
+                fun test() {
+                    val result = getSomeList().filter { it.isValid() }.filterNotNull()
+                }
+            """.trimIndent(),
+        issueDescription = "Replace mapNotNull { it } with filterNotNull()",
+    )
+  }
+}


### PR DESCRIPTION
Adds a new rule to enforce using `filterNotNull` instead of `mapNotNull { it }` for filtering out nulls. Autocorrects.