### PR TITLE
Fix false positives in DoNotUseDirectReceiverReferenceInsideWith

### DIFF
--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWith.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWith.kt
@@ -11,7 +11,9 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtValueArgumentName
 
 internal class DoNotUseDirectReceiverReferenceInsideWith(config: Config = empty) : Rule(config) {
   override val issue: Issue = Issue(
@@ -44,7 +46,13 @@ internal class DoNotUseDirectReceiverReferenceInsideWith(config: Config = empty)
   override fun visitExpression(expression: KtExpression) {
     super.visitExpression(expression)
     if (receiverList.isEmpty()) return
-    if (receiverList.contains(expression.text) && !expression.isReceiverParam() && !expression.isProperty()) {
+
+    if (
+        receiverList.contains(expression.text)
+        && !expression.isReceiverParam()
+        && !expression.isProperty()
+        && !expression.isNamedArgument()
+    ) {
       report(
           CodeSmell(
               issue = issue,
@@ -68,3 +76,5 @@ private fun KtExpression.isProperty(): Boolean {
 }
 
 private fun KtCallExpression.isWithExpr(): Boolean = calleeExpression?.textMatches("with") == true
+
+private fun KtExpression.isNamedArgument(): Boolean = this is KtNameReferenceExpression && parent is KtValueArgumentName

--- a/src/test/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWithTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWithTest.kt
@@ -164,7 +164,7 @@ internal class DoNotUseDirectReceiverReferenceInsideWithTest {
                 )
             )
         }
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     assertThat(findings).isEmpty()

--- a/src/test/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWithTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/DoNotUseDirectReceiverReferenceInsideWithTest.kt
@@ -151,6 +151,26 @@ internal class DoNotUseDirectReceiverReferenceInsideWithTest {
   }
 
   @Test
+  fun `using a named argument with the receiver name has no errors `() {
+    val findings = rule.lint(
+        """
+        val request = with(entrepreneur) {
+            ConfirmCustomerTypeRequest(
+                companySearch = null,
+                entrepreneur = EntrepreneurCustomerInfo(
+                    companyName = Property(companyName),
+                    ico = Property(ico.value),
+                    dic = Property(dic?.value)
+                )
+            )
+        }
+        """.trimIndent()
+    )
+
+    assertThat(findings).isEmpty()
+  }
+
+  @Test
   fun `using a parameter within a function has no errors`() {
     val findings = rule.lint(
         """


### PR DESCRIPTION
When a named argument is used inside a `with` block which shares a name of the receiver, we incorrectly identify this as a linting issue. Instead, we should skip named arguments

Fixes #124 