### PR TITLE
ci: Update gradle actions used by CI

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
             cache-read-only: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
       - name: Run checks

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -18,12 +18,13 @@ jobs:
           java-version-file: '.java-version'
 
       - name: Verify gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+            gradle-home-cache-cleanup: true
+            cache-read-only: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
       - name: Run checks
         run: |


### PR DESCRIPTION
The current versions we use are severely outdated and no longer working:
https://github.com/Faire/faire-detekt-rules/actions/runs/18010217593/job/51240641578?pr=132