### PR TITLE
Implement autocorrect on KtFile.modifiedText

### DIFF
--- a/src/main/kotlin/com/faire/detekt/rules/AlwaysUseIsTrueOrIsFalse.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/AlwaysUseIsTrueOrIsFalse.kt
@@ -1,14 +1,12 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 /**
@@ -35,7 +33,8 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * ```
  */
 internal class AlwaysUseIsTrueOrIsFalse(config: Config = Config.empty) :
-    Rule(config, "Do not use isEqualTo(true) or isEqualTo(false), use isTrue() or isFalse()") {
+    AutoCorrectRule(config, "Do not use isEqualTo(true) or isEqualTo(false), use isTrue() or isFalse()") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -57,13 +56,8 @@ internal class AlwaysUseIsTrueOrIsFalse(config: Config = Config.empty) :
       )
 
       if (autoCorrect) {
-          if (isEqualToExpression.isComparingToTrue()) {
-            val isTrueExpression = KtPsiFactory(isEqualToExpression.project).createExpression("isTrue()")
-            isEqualToExpression.astReplace(isTrueExpression)
-          } else {
-            val isFalseExpression = KtPsiFactory(isEqualToExpression.project).createExpression("isFalse()")
-            isEqualToExpression.astReplace(isFalseExpression)
-          }
+        val replacement = if (isEqualToExpression.isComparingToTrue()) "isTrue()" else "isFalse()"
+        pending.add(isEqualToExpression.text to replacement)
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotAssertIsEqualOnTheResultOfSingle.kt
@@ -1,15 +1,13 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 /**
@@ -27,7 +25,8 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * ```
  */
 internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.empty) :
-    Rule(config, "use containsOnly() instead of asserting isEqual() on the result of single()") {
+    AutoCorrectRule(config, "use containsOnly() instead of asserting isEqual() on the result of single()") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -50,13 +49,11 @@ internal class DoNotAssertIsEqualOnTheResultOfSingle(config: Config = Config.emp
     )
 
     if (autoCorrect) {
-      argumentForAssertThatExpression.lastChild.delete() // Delete "single()"
-      argumentForAssertThatExpression.lastChild.delete() // Delete "."
+      // assertThat(x.single()).isEqualTo(y) -> assertThat(x).containsOnly(y)
+      val collectionExpr = (argumentForAssertThatExpression as KtDotQualifiedExpression).receiverExpression.text
+      val isEqualArgs = (isEqualExpression as? KtCallExpression)?.valueArgumentList?.text
 
-      val argumentsForIsEqualExpression = (isEqualExpression as? KtCallExpression)?.valueArgumentList?.text
-      isEqualExpression.astReplace(
-          KtPsiFactory(isEqualExpression).createExpression("containsOnly$argumentsForIsEqualExpression"),
-      )
+      pending.add(expression.text to "assertThat($collectionExpr).containsOnly$isEqualArgs")
     }
   }
 

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseHasSizeForEmptyListInAssert.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseHasSizeForEmptyListInAssert.kt
@@ -1,14 +1,12 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 import org.jetbrains.kotlin.resolve.calls.util.getValueArgumentsInParentheses
 
@@ -34,7 +32,8 @@ import org.jetbrains.kotlin.resolve.calls.util.getValueArgumentsInParentheses
  * ```
  */
 internal class DoNotUseHasSizeForEmptyListInAssert(config: Config = Config.empty) :
-    Rule(config, "Do not call hasSize(0) on an empty collection, call isEmpty().") {
+    AutoCorrectRule(config, "Do not call hasSize(0) on an empty collection, call isEmpty().") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -55,8 +54,7 @@ internal class DoNotUseHasSizeForEmptyListInAssert(config: Config = Config.empty
       )
 
       if (autoCorrect) {
-        val isEmptyExpression = KtPsiFactory(hasSizeExpression).createExpression("isEmpty()")
-        hasSizeExpression.astReplace(isEmptyExpression)
+        pending.add(hasSizeExpression.text to "isEmpty()")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseIsEqualToWhenArgumentIsOne.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseIsEqualToWhenArgumentIsOne.kt
@@ -1,15 +1,13 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import com.faire.detekt.utils.usesSizeProperty
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 private val ONE_TEXTS = setOf("1.0", "1", "1L", "1.0f", "1f", "1.0F", "0x1", "0b1")
@@ -29,7 +27,8 @@ private val ONE_TEXTS = setOf("1.0", "1", "1L", "1.0f", "1f", "1.0F", "0x1", "0b
  * ```
  */
 internal class DoNotUseIsEqualToWhenArgumentIsOne(config: Config = Config.empty) :
-    Rule(config, "Do not use isEqualTo(1), use isOne() instead.") {
+    AutoCorrectRule(config, "Do not use isEqualTo(1), use isOne() instead.") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -54,8 +53,7 @@ internal class DoNotUseIsEqualToWhenArgumentIsOne(config: Config = Config.empty)
       )
 
       if (autoCorrect) {
-        val isOneExpression = KtPsiFactory(isEqualToExpression).createExpression("isOne()")
-        isEqualToExpression.astReplace(isOneExpression)
+        pending.add(isEqualToExpression.text to "isOne()")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseIsEqualToWhenArgumentIsZero.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseIsEqualToWhenArgumentIsZero.kt
@@ -1,15 +1,13 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import com.faire.detekt.utils.usesSizeProperty
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 private val ZERO_TEXTS = setOf("0.0", "0", "0L", "0.0f", "0f", "0.0F", "0x0", "0b0")
@@ -29,7 +27,8 @@ private val ZERO_TEXTS = setOf("0.0", "0", "0L", "0.0f", "0f", "0.0F", "0x0", "0
  * ```
  */
 internal class DoNotUseIsEqualToWhenArgumentIsZero(config: Config = Config.empty) :
-    Rule(config, "Do not use isEqualTo(0), use isZero() instead.") {
+    AutoCorrectRule(config, "Do not use isEqualTo(0), use isZero() instead.") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -54,8 +53,7 @@ internal class DoNotUseIsEqualToWhenArgumentIsZero(config: Config = Config.empty
       )
 
       if (autoCorrect) {
-        val isZeroExpression = KtPsiFactory(isEqualToExpression).createExpression("isZero()")
-        isEqualToExpression.astReplace(isZeroExpression)
+        pending.add(isEqualToExpression.text to "isZero()")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUsePropertyAccessInAssert.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUsePropertyAccessInAssert.kt
@@ -1,14 +1,12 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.faire.detekt.utils.isAssertThat
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 
 /**
  * Do not use property access syntax with assertion methods.
@@ -24,7 +22,11 @@ import org.jetbrains.kotlin.psi.psiUtil.astReplace
  */
 
 internal class DoNotUsePropertyAccessInAssert(config: Config = Config.empty) :
-    Rule(config, "Do not use property access syntax with assertion methods. Do not remove the parenthesis.") {
+    AutoCorrectRule(
+        config,
+        "Do not use property access syntax with assertion methods. Do not remove the parenthesis.",
+    ) {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -41,9 +43,7 @@ internal class DoNotUsePropertyAccessInAssert(config: Config = Config.empty) :
       )
 
       if (autoCorrect) {
-        val withParenthesisExpression = KtPsiFactory(selectorExpression)
-            .createExpression("${selectorExpression.text}()")
-        selectorExpression.astReplace(withParenthesisExpression)
+        pending.add(selectorExpression.text to "${selectorExpression.text}()")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/DoNotUseSingleOnFilter.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/DoNotUseSingleOnFilter.kt
@@ -1,10 +1,10 @@
 package com.faire.detekt.rules
 
-import com.faire.detekt.utils.simplifyCollectionPatterns
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
@@ -25,7 +25,8 @@ private val FILTER_REGEX = ".*\\.*filter\\s*(\\{|\\().+".toRegex()
  * This augments the `UnnecessaryFilter` detekt rule which does not cover `.single` as of 1.21.0.
  */
 internal class DoNotUseSingleOnFilter(config: Config = Config.empty) :
-    Rule(config, "Do not use single() with filter { ... }, use single { ... } instead") {
+    AutoCorrectRule(config, "Do not use single() with filter { ... }, use single { ... } instead") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -48,13 +49,21 @@ internal class DoNotUseSingleOnFilter(config: Config = Config.empty) :
     )
 
     if (autoCorrect) {
-      removeCallToSingle(expression)
-      receiverExpression.simplifyCollectionPatterns("single")
+      val receiverDotExpr = receiverExpression as? KtDotQualifiedExpression ?: return
+      val filterCall = receiverDotExpr.selectorExpression as? KtCallExpression ?: return
+      val filterCallText = filterCall.text
+      val newCallText = filterCallText.replaceFirst("filter", "single")
+      val baseReceiverText = receiverDotExpr.receiverExpression.text
+      // Extract whitespace/dot between base receiver and filter call from the expression text
+      val betweenBaseAndFilter = receiverDotExpr.text.removePrefix(baseReceiverText).removeSuffix(filterCallText)
+
+      pending.add(expression.text to "$baseReceiverText$betweenBaseAndFilter$newCallText")
     }
   }
-
-  private fun removeCallToSingle(expression: KtDotQualifiedExpression) {
-    expression.lastChild.delete()
-    expression.lastChild.delete()
-  }
 }
+
+private fun buildArgumentsText(call: KtCallExpression): String = if (call.lambdaArguments.isNotEmpty()) {
+    " ${call.lambdaArguments.joinToString { it.text }}"
+  } else {
+    "(${call.valueArguments.joinToString { it.text }})"
+  }

--- a/src/main/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFiltering.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/FilterNotNullOverMapNotNullForFiltering.kt
@@ -1,11 +1,9 @@
 package com.faire.detekt.rules
 
-import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
-import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
@@ -24,7 +22,8 @@ import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
  * ```
  */
 internal class FilterNotNullOverMapNotNullForFiltering(config: Config = Config.empty) :
-    Rule(config, "Use filterNotNull() instead of mapNotNull { it }") {
+    AutoCorrectRule(config, "Use filterNotNull() instead of mapNotNull { it }") {
+
   override fun visitCallExpression(expression: KtCallExpression) {
     super.visitCallExpression(expression)
 
@@ -43,22 +42,8 @@ internal class FilterNotNullOverMapNotNullForFiltering(config: Config = Config.e
       )
 
       if (autoCorrect) {
-        // Rename "mapNotNull" to "filterNotNull"
-        val calleeLeaf = callee.node.findChildByType(KtTokens.IDENTIFIER)
-        (calleeLeaf?.psi as? LeafPsiElement)?.rawReplaceWithText("filterNotNull")
-
-        // Remove lambda argument and any preceding whitespace
-        val expressionNode = expression.node
-        val lambdaArgNode = expression.lambdaArguments.first().node
-        val blankNode = lambdaArgNode.treePrev?.takeIf { it.text.isBlank() }
-        if (blankNode != null) {
-          expressionNode.removeChild(blankNode)
-        }
-        expressionNode.removeChild(lambdaArgNode)
-
-        // Add empty parentheses
-        expressionNode.addChild(LeafPsiElement(KtTokens.LPAR, "("), null)
-        expressionNode.addChild(LeafPsiElement(KtTokens.RPAR, ")"), null)
+        // mapNotNull { it } -> filterNotNull()
+        pending.add(expression.text to "filterNotNull()")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/NoEmptyLinesInConstructorParameters.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoEmptyLinesInConstructorParameters.kt
@@ -1,14 +1,16 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtParameterList
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
+
+private val BLANK_LINE_REGEX = Regex("""\n([ \t]*\n)+""")
 
 /**
  * Detects and removes empty lines within constructor parameter lists.
@@ -53,7 +55,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  * ```
  */
 internal class NoEmptyLinesInConstructorParameters(config: Config = Config.empty) :
-    Rule(config, description = "Constructor parameter lists should not contain empty lines") {
+    AutoCorrectRule(config, description = "Constructor parameter lists should not contain empty lines") {
+
   override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
     super.visitPrimaryConstructor(constructor)
     checkConstructorParameters(constructor.valueParameterList)
@@ -84,17 +87,11 @@ internal class NoEmptyLinesInConstructorParameters(config: Config = Config.empty
         Finding(entity = Entity.from(parameterList), message = description),
     )
 
-    // Auto-correct by removing blank lines
     if (autoCorrect) {
-        for (whitespaceNode in nodesWithBlankLines) {
-          // Replace multiple consecutive newlines with a single newline
-          // Preserve the indentation from the last line
-          val lines = whitespaceNode.text.split("\n")
-          val lastLine = lines.lastOrNull() ?: ""
-          val correctedWhitespace = "\n$lastLine"
-
-          whitespaceNode.rawReplaceWithText(correctedWhitespace)
-        }
-      }
+      val originalText = parameterList.text
+      // Collapse blank lines: replace sequences of newlines (with optional whitespace) with a single newline
+      val fixedText = BLANK_LINE_REGEX.replace(originalText, "\n")
+      pending.add(originalText to fixedText)
+    }
   }
 }

--- a/src/main/kotlin/com/faire/detekt/rules/NoNonPrivateGlobalVariables.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/NoNonPrivateGlobalVariables.kt
@@ -1,13 +1,10 @@
 package com.faire.detekt.rules
 
-import com.intellij.psi.impl.source.tree.LeafPsiElement
-import com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
@@ -29,59 +26,22 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * class InchesConverter
  * ```
  */
-internal class NoNonPrivateGlobalVariables(config: Config = Config.empty) : Rule(config, RULE_DESCRIPTION) {
-  private val violations = mutableListOf<KtProperty>()
-
-  override fun visitKtFile(file: KtFile) {
-    violations.clear()
-    super.visitKtFile(file)
-
-    // Report all violations first using original offsets, then autocorrect in reverse
-    // order so that modifications to later properties don't invalidate earlier positions.
-    for (property in violations) {
-      report(Finding(entity = Entity.from(property), message = RULE_DESCRIPTION))
-    }
-
-    if (autoCorrect) {
-      for (property in violations.reversed()) {
-        val modifierList = property.modifierList
-        val internalNode = modifierList?.node?.findChildByType(KtTokens.INTERNAL_KEYWORD)
-        val publicNode = modifierList?.node?.findChildByType(KtTokens.PUBLIC_KEYWORD)
-        val existingVisibilityNode = internalNode ?: publicNode
-
-        if (existingVisibilityNode != null) {
-          // Replace existing visibility modifier text directly
-          (existingVisibilityNode.psi as LeafPsiElement).rawReplaceWithText("private")
-        } else if (modifierList != null) {
-          // Has modifier list but no visibility keyword (e.g., "const val")
-          val modifierListNode = modifierList.node
-          modifierListNode.addChild(
-            LeafPsiElement(KtTokens.PRIVATE_KEYWORD, "private"),
-            modifierListNode.firstChildNode,
-          )
-          modifierListNode.addChild(
-            PsiWhiteSpaceImpl(" "),
-            modifierListNode.firstChildNode.treeNext,
-          )
-        } else {
-          // No modifier list (e.g., bare "val bar = 1")
-          val propertyNode = property.node
-          propertyNode.addChild(
-            LeafPsiElement(KtTokens.PRIVATE_KEYWORD, "private"),
-            propertyNode.firstChildNode,
-          )
-          propertyNode.addChild(
-            PsiWhiteSpaceImpl(" "),
-            propertyNode.firstChildNode.treeNext,
-          )
-        }
-      }
-    }
-  }
+internal class NoNonPrivateGlobalVariables(config: Config = Config.empty) :
+    AutoCorrectRule(config, RULE_DESCRIPTION) {
 
   override fun visitProperty(property: KtProperty) {
     if (property.isTopLevel && !property.isPrivate() && !property.isExtensionDeclaration()) {
-      violations.add(property)
+      report(Finding(entity = Entity.from(property), message = RULE_DESCRIPTION))
+
+      if (autoCorrect) {
+        val propertyText = property.text
+        val replacement = when {
+          property.hasModifier(KtTokens.INTERNAL_KEYWORD) -> propertyText.replaceFirst("internal", "private")
+          property.hasModifier(KtTokens.PUBLIC_KEYWORD) -> propertyText.replaceFirst("public", "private")
+          else -> "private $propertyText"
+        }
+        pending.add(propertyText to replacement)
+      }
     }
   }
 

--- a/src/main/kotlin/com/faire/detekt/rules/PreferIgnoreCase.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/PreferIgnoreCase.kt
@@ -1,12 +1,10 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 private val LOWERCASE_CALLS = setOf("lowercase()", "toLowerCase()")
@@ -28,7 +26,11 @@ private val IGNORE_CASE_FUNCTIONS = setOf(
  * Bad: `someString.lowercase().contains("foo")`
  */
 internal class PreferIgnoreCase(config: Config = Config.empty) :
-    Rule(config, "use ignoreCase=true with various string matching functions without converting to lowercase") {
+    AutoCorrectRule(
+        config,
+        "use ignoreCase=true with various string matching functions without converting to lowercase",
+    ) {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
     val selectorExpression = expression.selectorExpression ?: return
@@ -49,9 +51,11 @@ internal class PreferIgnoreCase(config: Config = Config.empty) :
           return
         }
         val newArguments = arguments.text.dropLast(1) + ", ignoreCase = true)"
-        arguments.astReplace(KtPsiFactory(expression).createCallArguments(newArguments))
-        // We can't just delete receiverExpression.lastChild; it'd create an empty/invalid DotQualifiedExpression node.
-        expression.firstChild.astReplace(receiverExpression.firstChild)
+        val functionName = selectorExpression.referenceExpression()?.text ?: return
+        // Strip .lowercase()/.toLowerCase() from receiver to get the base string expression
+        val baseReceiver = receiverExpression.firstChild.text
+
+        pending.add(expression.text to "$baseReceiver.$functionName$newArguments")
       }
     }
   }

--- a/src/main/kotlin/com/faire/detekt/rules/PreventBannedImports.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/PreventBannedImports.kt
@@ -1,13 +1,10 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtImportDirective
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
-import org.jetbrains.kotlin.resolve.ImportPath
 
 /**
  * Prevent a configurable list of imports, optionally with auto-correction to a configurable replacement import.
@@ -18,7 +15,8 @@ import org.jetbrains.kotlin.resolve.ImportPath
  * Good: `import kotlin.math.max`
  * Bad: `import java.lang.Integer.max`
  */
-internal open class PreventBannedImports(config: Config = Config.empty) : Rule(config, "Prevent unwanted imports") {
+internal open class PreventBannedImports(config: Config = Config.empty) :
+    AutoCorrectRule(config, "Prevent unwanted imports") {
   private val withAlternatives: Map<String, String> by lazy { getConfiguredWithAlternatives() }
   private val withoutAlternatives: List<String> by lazy { getConfiguredWithoutAlternatives() }
 
@@ -63,13 +61,8 @@ internal open class PreventBannedImports(config: Config = Config.empty) : Rule(c
         )
         if (!didReportIssue) continue
         if (autoCorrect) {
-          val newImport = KtPsiFactory(importDirective)
-              .createImportDirective(
-                  ImportPath.fromString(
-                      validImport + importReference.removePrefix(invalidImport),
-                  ),
-              )
-          importDirective.astReplace(newImport)
+          val newImportPath = validImport + importReference.removePrefix(invalidImport)
+          pending.add(importDirective.text to "import $newImportPath")
         }
       }
     }

--- a/src/main/kotlin/com/faire/detekt/rules/UseFirstNotNullOf.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseFirstNotNullOf.kt
@@ -1,10 +1,10 @@
 package com.faire.detekt.rules
 
-import com.faire.detekt.utils.simplifyCollectionPatterns
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 
 private val MAP_NOT_NULL_REGEX = """.*\.*mapNotNull\s*[{(].+""".toRegex()
@@ -22,7 +22,8 @@ private val MAP_NOT_NULL_REGEX = """.*\.*mapNotNull\s*[{(].+""".toRegex()
  *               Using `.mapNotNull { ... }.first()` is more verbose.
  */
 internal class UseFirstNotNullOf(config: Config = Config.empty) :
-    Rule(config, "use firstNotNullOf() instead of mapNotNull followed by first()") {
+    AutoCorrectRule(config, "use firstNotNullOf() instead of mapNotNull followed by first()") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -40,24 +41,34 @@ internal class UseFirstNotNullOf(config: Config = Config.empty) :
     )
 
     if (autoCorrect) {
-      removeCallToFirst(expression)
-      mayBeRemoveCallToAsSequence(receiverExpression)
+      val mapNotNullCall = receiverExpression.selectorExpression as? KtCallExpression ?: return
+      val mapNotNullCallText = mapNotNullCall.text
+      val newCallText = mapNotNullCallText.replaceFirst("mapNotNull", "firstNotNullOf")
 
-      receiverExpression.simplifyCollectionPatterns("firstNotNullOf")
+      val mapNotNullReceiver = receiverExpression.receiverExpression
+      val shouldRemoveAsSequence = mapNotNullReceiver is KtDotQualifiedExpression &&
+          mapNotNullReceiver.lastChild.text == "asSequence()"
+
+      if (shouldRemoveAsSequence) {
+        // Strip .asSequence() — use the receiver before asSequence() as base
+        val asSeqExpr = mapNotNullReceiver as KtDotQualifiedExpression
+        val baseReceiverText = asSeqExpr.receiverExpression.text
+        val asSeqCallText = asSeqExpr.selectorExpression?.text ?: return
+        // Get whitespace/dot between base receiver and asSequence call
+        val betweenBaseAndAsSeq = asSeqExpr.text.removePrefix(baseReceiverText).removeSuffix(asSeqCallText)
+        pending.add(expression.text to "$baseReceiverText$betweenBaseAndAsSeq$newCallText")
+      } else {
+        val baseReceiverText = mapNotNullReceiver.text
+        val betweenBaseAndMapNotNull =
+          receiverExpression.text.removePrefix(baseReceiverText).removeSuffix(mapNotNullCallText)
+        pending.add(expression.text to "$baseReceiverText$betweenBaseAndMapNotNull$newCallText")
+      }
     }
   }
 }
 
-private fun removeCallToFirst(expression: KtDotQualifiedExpression) {
-  expression.lastChild.delete() // Delete "first()"
-  expression.lastChild.delete() // Delete "."
-}
-
-private fun mayBeRemoveCallToAsSequence(expression: KtDotQualifiedExpression) {
-  // Check whether the child immediately preceding the receiver expression is "asSequence()"
-  val receiverExpression = expression.receiverExpression
-  if (receiverExpression.lastChild.text != "asSequence()") return
-
-  receiverExpression.lastChild.delete() // Delete "asSequence()"
-  receiverExpression.lastChild.delete() // Delete "."
-}
+private fun buildArgumentsText(call: KtCallExpression): String = if (call.lambdaArguments.isNotEmpty()) {
+    " ${call.lambdaArguments.joinToString { it.text }}"
+  } else {
+    "(${call.valueArguments.joinToString { it.text }})"
+  }

--- a/src/main/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFind.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFind.kt
@@ -1,17 +1,15 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 private val BANNED_CLASS_IDS = listOf(
@@ -36,16 +34,17 @@ private val BANNED_CLASS_IDS = listOf(
  */
 
 internal class UseFirstOrNullInsteadOfFind(config: Config = Config.empty) :
-    Rule(config, "Use firstOrNull() instead of find()"),
+    AutoCorrectRule(config, "Use firstOrNull() instead of find()"),
     RequiresAnalysisApi {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
     val selectorExpression = expression.selectorExpression ?: return
-    val receiverExpression = expression.receiverExpression
-
     if (selectorExpression.referenceExpression()?.text != "find") return
+
     val findExpression = selectorExpression as? KtCallExpression ?: return
+    val receiverExpression = expression.receiverExpression
 
     analyze(expression) {
       val receiverType = receiverExpression.expressionType ?: return@analyze
@@ -59,14 +58,25 @@ internal class UseFirstOrNullInsteadOfFind(config: Config = Config.empty) :
       )
     }
 
-    if (autoCorrect) {
-      val arguments = if ((findExpression).lambdaArguments.isNotEmpty()) {
-        " ${findExpression.lambdaArguments.joinToString { it.text }}"
-      } else {
-        "(${findExpression.valueArguments.joinToString { it.text }})"
+    if (!autoCorrect) return
+
+    val replacementText = buildString {
+      append("firstOrNull")
+
+      if (findExpression.typeArgumentList != null) {
+        append(findExpression.typeArgumentList!!.text)
       }
 
-      findExpression.astReplace(KtPsiFactory(findExpression).createExpression("firstOrNull$arguments"))
+      if (findExpression.lambdaArguments.isNotEmpty()) {
+        append(" ")
+        append(findExpression.lambdaArguments.joinToString(" ") { it.text })
+      } else {
+        append("(")
+        append(findExpression.valueArguments.joinToString(", ") { it.text })
+        append(")")
+      }
     }
+
+    pending.add(findExpression.text to replacementText)
   }
 }

--- a/src/main/kotlin/com/faire/detekt/rules/UseMapNotNullInsteadOfFilterNotNull.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseMapNotNullInsteadOfFilterNotNull.kt
@@ -1,10 +1,10 @@
 package com.faire.detekt.rules
 
-import com.faire.detekt.utils.simplifyCollectionPatterns
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 
 private val MAP_REGEX = ".*\\.*map\\s*(\\{|\\().+".toRegex()
@@ -26,7 +26,8 @@ private val MAP_REGEX = ".*\\.*map\\s*(\\{|\\().+".toRegex()
  *  for larger collections.
  */
 internal class UseMapNotNullInsteadOfFilterNotNull(config: Config = Config.empty) :
-    Rule(config, "use mapNotNull() instead of map followed by filerNotNull()") {
+    AutoCorrectRule(config, "use mapNotNull() instead of map followed by filerNotNull()") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -44,13 +45,20 @@ internal class UseMapNotNullInsteadOfFilterNotNull(config: Config = Config.empty
     )
 
     if (autoCorrect) {
-      removeCallToFilterNotNull(expression)
-      receiverExpression.simplifyCollectionPatterns("mapNotNull")
+      val receiverDotExpr = receiverExpression as? KtDotQualifiedExpression ?: return
+      val mapCall = receiverDotExpr.selectorExpression as? KtCallExpression ?: return
+      val mapCallText = mapCall.text
+      val newCallText = mapCallText.replaceFirst("map", "mapNotNull")
+      val baseReceiverText = receiverDotExpr.receiverExpression.text
+      val betweenBaseAndMap = receiverDotExpr.text.removePrefix(baseReceiverText).removeSuffix(mapCallText)
+
+      pending.add(expression.text to "$baseReceiverText$betweenBaseAndMap$newCallText")
     }
   }
-
-  private fun removeCallToFilterNotNull(expression: KtDotQualifiedExpression) {
-    expression.lastChild.delete()
-    expression.lastChild.delete()
-  }
 }
+
+private fun buildArgumentsText(call: KtCallExpression): String = if (call.lambdaArguments.isNotEmpty()) {
+    " ${call.lambdaArguments.joinToString { it.text }}"
+  } else {
+    "(${call.valueArguments.joinToString { it.text }})"
+  }

--- a/src/main/kotlin/com/faire/detekt/rules/UseNoneMatchInsteadOfFirstOrNullIsNull.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseNoneMatchInsteadOfFirstOrNullIsNull.kt
@@ -1,14 +1,12 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 /**
@@ -28,11 +26,12 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * that the result was not null.
  */
 internal class UseNoneMatchInsteadOfFirstOrNullIsNull(config: Config = Config.empty) :
-    Rule(
+    AutoCorrectRule(
         config,
         "Use assertThat(collection).noneMatch { predicate } instead of " +
             "assertThat(collection.firstOrNull { predicate }).isNull()",
     ) {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -63,20 +62,15 @@ internal class UseNoneMatchInsteadOfFirstOrNullIsNull(config: Config = Config.em
     )
 
     if (autoCorrect) {
-      // Get the collection (receiver of firstOrNull)
       val collectionExpression = assertThatArgument.receiverExpression.text
 
-      // Get the predicate arguments from firstOrNull
       val predicateArgs = if (firstOrNullCall.lambdaArguments.isNotEmpty()) {
         " ${firstOrNullCall.lambdaArguments.joinToString { it.text }}"
       } else {
         "(${firstOrNullCall.valueArguments.joinToString { it.text }})"
       }
 
-      val newExpression = KtPsiFactory(expression.project).createExpression(
-          "assertThat($collectionExpression).noneMatch$predicateArgs",
-      )
-      expression.astReplace(newExpression)
+      pending.add(expression.text to "assertThat($collectionExpression).noneMatch$predicateArgs")
     }
   }
 }

--- a/src/main/kotlin/com/faire/detekt/rules/UseOfCollectionInsteadOfEmptyCollection.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseOfCollectionInsteadOfEmptyCollection.kt
@@ -1,40 +1,43 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
-import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
+
+private val EMPTY_COLLECTIONS = setOf("emptyList", "emptySet", "emptyMap")
 
 /**
  * Instead of using `emptyMap()`, `emptyList()` or `emptySet()` we should use `mapOf()`, `listOf()`, or `setOf()`.
  *
  * This code convention exists for the purpose of consistency.
  */
-internal class UseOfCollectionInsteadOfEmptyCollection(config: Config = Config.empty) : Rule(config, ISSUE) {
+internal class UseOfCollectionInsteadOfEmptyCollection(config: Config = Config.empty) :
+    AutoCorrectRule(config, ISSUE) {
+
   override fun visitCallExpression(expression: KtCallExpression) {
     super.visitCallExpression(expression)
 
-    val callee = expression.getCalleeExpressionIfAny() ?: return
+    val calleeText = expression.calleeExpression?.text ?: return
+    if (calleeText !in EMPTY_COLLECTIONS) return
 
-    if (callee.text in setOf("emptyList", "emptySet", "emptyMap")) {
-      report(
-          Finding(
-              entity = Entity.from(expression),
-              message = description,
-          ),
-      )
+    report(
+        Finding(
+            entity = Entity.from(expression),
+            message = description,
+        ),
+    )
 
-      if (autoCorrect) {
-        when (callee.text) {
-          "emptyList" -> callee.astReplace(KtPsiFactory(callee).createExpression("listOf"))
-          "emptySet" -> callee.astReplace(KtPsiFactory(callee).createExpression("setOf"))
-          "emptyMap" -> callee.astReplace(KtPsiFactory(callee).createExpression("mapOf"))
-        }
+    if (autoCorrect) {
+      val replacement = when (calleeText) {
+        "emptyList" -> "listOf"
+        "emptySet" -> "setOf"
+        "emptyMap" -> "mapOf"
+        else -> return
       }
+      val typeArgs = expression.typeArgumentList?.text.orEmpty()
+      pending.add(expression.text to "$replacement$typeArgs()")
     }
   }
 

--- a/src/main/kotlin/com/faire/detekt/rules/UseSetInsteadOfListToSet.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseSetInsteadOfListToSet.kt
@@ -1,12 +1,10 @@
 package com.faire.detekt.rules
 
+import com.faire.detekt.utils.AutoCorrectRule
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
-import dev.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.psiUtil.astReplace
 
 /**
  * Use `set()` instead of `list().toSet()`
@@ -20,7 +18,8 @@ import org.jetbrains.kotlin.psi.psiUtil.astReplace
  * ```
  */
 internal class UseSetInsteadOfListToSet(config: Config = Config.empty) :
-    Rule(config, "Use set() instead of list().toSet()") {
+    AutoCorrectRule(config, "Use set() instead of list().toSet()") {
+
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
 
@@ -39,12 +38,14 @@ internal class UseSetInsteadOfListToSet(config: Config = Config.empty) :
     )
 
     if (autoCorrect) {
-      expression.lastChild.delete() // Delete "toSet()"
-      expression.lastChild.delete() // Delete "."
+      // Replace .list().toSet() with .set()
+      val receiverDotExpr = receiverExpression as? KtDotQualifiedExpression ?: return
+      val listCallText = receiverDotExpr.selectorExpression?.text ?: return // "list()"
+      val baseReceiverText = receiverDotExpr.receiverExpression.text
+      // Extract whitespace/dot between base receiver and list() from the expression text
+      val betweenBaseAndList = receiverDotExpr.text.removePrefix(baseReceiverText).removeSuffix(listCallText)
 
-      val expressionToReplace = receiverExpression.lastChild // "list()"
-
-      expressionToReplace.astReplace(KtPsiFactory(expressionToReplace).createExpression("set()"))
+      pending.add(expression.text to "$baseReceiverText${betweenBaseAndList}set()")
     }
   }
 }

--- a/src/main/kotlin/com/faire/detekt/utils/AutoCorrectRule.kt
+++ b/src/main/kotlin/com/faire/detekt/utils/AutoCorrectRule.kt
@@ -1,0 +1,24 @@
+package com.faire.detekt.utils
+
+import dev.detekt.api.Config
+import dev.detekt.api.Rule
+import dev.detekt.api.modifiedText
+import org.jetbrains.kotlin.psi.KtFile
+
+internal abstract class AutoCorrectRule(config: Config, description: String) : Rule(config, description) {
+
+  protected val pending = mutableListOf<Pair<String, String>>()
+
+  override fun preVisit(root: KtFile) {
+    pending.clear()
+  }
+
+  override fun postVisit(root: KtFile) {
+    if (pending.isEmpty()) return
+    var text = root.modifiedText ?: root.text
+    for ((original, replacement) in pending) {
+      text = text.replaceFirst(original, replacement)
+    }
+    root.modifiedText = text
+  }
+}

--- a/src/test/kotlin/com/faire/detekt/utils/AutoCorrectRuleTest.kt
+++ b/src/test/kotlin/com/faire/detekt/utils/AutoCorrectRuleTest.kt
@@ -2,6 +2,7 @@ package com.faire.detekt.utils
 
 import dev.detekt.api.Config
 import dev.detekt.api.Rule
+import dev.detekt.api.modifiedText
 import dev.detekt.test.TestConfig
 import dev.detekt.test.lint
 import dev.detekt.test.utils.compileContentForTest
@@ -29,9 +30,13 @@ internal abstract class AutoCorrectRuleTest<T : Rule>(
         .`as`("Expected issues to be: '$issueDescription'")
         .extracting<String> { it.message }
         .allMatch { it == issueDescription }
-    assertThat(code.text).isEqualTo(expectedPostFormattedCode)
 
-    val postFormattedCode = compileContentForTest(code.text, fileName)
+    assertThat(code.modifiedText).isNotNull()
+    val modifiedText = code.modifiedText!!
+
+    assertThat(modifiedText).isEqualTo(expectedPostFormattedCode)
+
+    val postFormattedCode = compileContentForTest(modifiedText, fileName)
     assertThat(autoCorrectRule.lint(postFormattedCode)).isEmpty()
   }
 
@@ -43,6 +48,7 @@ internal abstract class AutoCorrectRuleTest<T : Rule>(
     val code = compileContentForTest(codeToLint, fileName)
     val findings = autoCorrectRule.lint(code)
     assertThat(code.text).isEqualTo(codeToLint)
+    assertThat(code.modifiedText).isNull()
     assertThat(findings).isEmpty()
   }
 


### PR DESCRIPTION
We use string/text replacement instead of PSI tree or ASTNode manipulation to avoid runtime exceptions in the K2 analyzer API due to modified PSI trees.

Fixes #150.  Verified by doing a local maven publish, and running on a custom file that previously generated the exception.