### PR TITLE
Fix UseFirstOrNullInsteadOfFind false negatives on safe calls

### DIFF
--- a/src/main/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFind.kt
+++ b/src/main/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFind.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 private val BANNED_CLASS_IDS = listOf(
@@ -39,20 +41,28 @@ internal class UseFirstOrNullInsteadOfFind(config: Config = Config.empty) :
 
   override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
     super.visitDotQualifiedExpression(expression)
+    inspectQualifiedExpression(expression)
+  }
 
-    val selectorExpression = expression.selectorExpression ?: return
+  override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
+    super.visitSafeQualifiedExpression(expression)
+    inspectQualifiedExpression(expression)
+  }
+
+  private fun inspectQualifiedExpression(qualifiedExpression: KtQualifiedExpression) {
+    val selectorExpression = qualifiedExpression.selectorExpression ?: return
     if (selectorExpression.referenceExpression()?.text != "find") return
 
     val findExpression = selectorExpression as? KtCallExpression ?: return
-    val receiverExpression = expression.receiverExpression
+    val receiverExpression = qualifiedExpression.receiverExpression
 
-    analyze(expression) {
+    analyze(qualifiedExpression) {
       val receiverType = receiverExpression.expressionType ?: return@analyze
       if (BANNED_CLASS_IDS.none { receiverType.isSubtypeOf(it) }) return@analyze
 
       report(
           Finding(
-              entity = Entity.from(expression),
+              entity = Entity.from(qualifiedExpression),
               message = description,
           ),
       )

--- a/src/test/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFindTest.kt
+++ b/src/test/kotlin/com/faire/detekt/rules/UseFirstOrNullInsteadOfFindTest.kt
@@ -51,6 +51,23 @@ internal class UseFirstOrNullInsteadOfFindTest(private val env: KotlinEnvironmen
   }
 
   @Test
+  fun `find{ } is flagged on nullable collection chain`() {
+    assertThat(
+        rule.lintWithContext(
+            env,
+            """
+              data class Option(val id: Int)
+              data class PaymentOptions(val items: List<Option>)
+
+              fun foo(paymentOptions: PaymentOptions?, selectedOptionIds: Set<Int>) {
+                val selectedPaymentOption = paymentOptions?.items?.find { opt -> opt.id in selectedOptionIds }
+              }
+            """.trimIndent(),
+        ),
+    ).hasSize(1)
+  }
+
+  @Test
   fun `find() on unrelated type is not flagged`() {
     assertThat(
         rule.lintWithContext(


### PR DESCRIPTION
Fixes #154 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- handle both dot-qualified (`.find`) and safe-qualified (`?.find`) calls in `UseFirstOrNullInsteadOfFind`
- keep existing type analysis/autocorrect behavior while extending coverage to nullable chains
- add a regression test for `paymentOptions?.items?.find { ... }` so nullable collection chains are flagged

## Testing
- `./gradlew test --tests "com.faire.detekt.rules.UseFirstOrNullInsteadOfFindTest"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fc2c964-eb60-45a8-9ce6-15b1ff29f806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fc2c964-eb60-45a8-9ce6-15b1ff29f806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

